### PR TITLE
Rename module to decidim-module-department_admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 Following Semantic Versioning 2.
 
 ## next version:
+
+## Version 0.4.0 (MAJOR)
+- Rename module to decidim-module-department_admin
+- I18N: Add czech language (#48)
 - Doc: correct how to install the module in the README
 
 ## Version 0.3.4 (PATCH)

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ To create a user with a department admin role, go to admin panel/PARTICIPANTS/Ad
 Add this line to your application's Gemfile if you would like to always have the latest (edge) version:
 
 ```ruby
-gem "decidim-department_admin", git: "https://github.com/gencat/decidim-department-admin.git"
+gem "decidim-department_admin", git: "https://github.com/gencat/decidim-module-department-admin.git"
 ```
 
 Or, add a line like the following to your application's Gemfile if you would like to have the latest stable from the version of your choice, in this case `0.3.x`:
 
 ```ruby
-gem "decidim-department_admin", "~> 0.3.4", git: "https://github.com/gencat/decidim-department-admin.git"
+gem "decidim-department_admin", "~> 0.3.4", git: "https://github.com/gencat/decidim-module-department-admin.git"
 ```
 
 Edit your app's `config/application.rb` file to enforce railties ordering:

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This holds the decidim-meetings version.
+  # This holds the decidim-module-department_admin version.
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.3.4"
+      "0.4.0"
     end
   end
 end


### PR DESCRIPTION
Follow Decidim's recommended naming for modules as noted in issue https://github.com/gencat/decidim-department-admin/issues/22