### PR TITLE
Fix compatibility assemblies permissions with v0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Following Semantic Versioning 2.
 
 ## next version:
+## Version 0.4.2 (MINOR)
+- Add compatibility with new permissions in Decidim 0.24 for Assemblies views.
+- Fix: condition in AssemblyControllerDecorator doesn't take into account when the user is an assembly admin.
 
 ## Version 0.4.1 (MINOR)
 - Fix: Select only assemblies with same area when is a deparment admin 

--- a/app/decorators/decidim/assemblies/admin/assemblies_controller_decorator.rb
+++ b/app/decorators/decidim/assemblies/admin/assemblies_controller_decorator.rb
@@ -10,10 +10,10 @@ Decidim::Assemblies::Admin::AssembliesController.class_eval do
   alias_method :original_organization_assemblies, :collection
 
   def collection
-    if current_user.admin?
-      original_organization_assemblies
-    else
+    if current_user.department_admin?
       ::Decidim::Assemblies::AssembliesWithUserRole.for(current_user)
+    else
+      original_organization_assemblies
     end
   end
 end

--- a/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -53,11 +53,12 @@
         </thead>
         <tbody>
           <% @assemblies.each do |assembly| %>
+            <% next unless allowed_to? :list, :assembly, assembly: assembly %>
             <tr>
               <td>
                 <% if assembly.promoted? %>
                   <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.assembly.fields.promoted", scope: "decidim.admin") %>">
-                    <%= icon "star" %>
+                    <%= icon "star", role: "img", "aria-hidden": true %>
                   </span>
                 <% end %>
                 <% if allowed_to? :update, :assembly, assembly: assembly %>
@@ -103,16 +104,22 @@
                 <% end %>
               </td>
               <td class="table-list__actions">
-                <% if allowed_to? :create, :assembly, assembly: assembly %>
+                <% if allowed_to? :export, :assembly, assembly: assembly %>
                   <%= icon_link_to "data-transfer-download", assembly_export_path(assembly), t("actions.export", scope: "decidim.admin"), method: :post, class: "action-icon--export" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
-                <% if allowed_to? :create, :assembly, assembly: assembly %>
+                <% if allowed_to? :copy, :assembly, assembly: assembly %>
                   <%= icon_link_to "clipboard", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :assembly, assembly: assembly %>
                   <%= icon_link_to "pencil", edit_assembly_path(assembly), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if assembly.children.count.positive? || allowed_to?(:create, :assembly) %>
@@ -120,10 +127,14 @@
                       url_for(query_params_with(parent_id_eq: assembly.id)),
                       t("decidim.admin.titles.assemblies"),
                       class: "action-icon--dial #{'highlighted' if assembly.children.count.positive?}" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :preview, :assembly, assembly: assembly %>
                   <%= icon_link_to "eye", decidim_assemblies.assembly_path(assembly), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.4.1"
+      "0.4.2"
     end
   end
 end


### PR DESCRIPTION
- Add compatibility with new permissions in Decidim 0.24 for Assemblies views.
- Fix: condition in AssemblyControllerDecorator doesn't take into account when the user is an assembly admin.
- Bump version to 0.4.2