### PR TITLE
Fix ParticipatorySpaceResourceableDecorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.7.2 (PATCH)
+- Fix: Use prepend instead of overriding to apply Lib::Decidim::ParticipatorySpaceResourceableDecorator
+
 ## Version 0.7.1 (PATCH)
 - Fix Zeitwerk errors with decorators
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "r
 gem "execjs", "~> 2.7.0"
 
 gem "deface"
+gem "uri", ">= 0.13.1"
 
 group :development, :test do
   gem "bootsnap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-department_admin (0.7.1)
+    decidim-department_admin (0.7.2)
       decidim-admin (~> 0.27.0)
       decidim-core (~> 0.27.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,7 +772,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (0.13.1)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -839,6 +839,7 @@ DEPENDENCIES
   social-share-button
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
+  uri (>= 0.13.1)
   web-console (~> 3.5)
 
 RUBY VERSION

--- a/app/decorators/lib/decidim/participatory_space_resourceable_decorator.rb
+++ b/app/decorators/lib/decidim/participatory_space_resourceable_decorator.rb
@@ -2,32 +2,35 @@
 
 module Lib::Decidim::ParticipatorySpaceResourceableDecorator
   #
-  # This decorator overrided method to avoid .to_sym error when logged in user is Department Admin
-  # Override affects only line `case role_name&.to_sym`
-  # Furthermore added new ParticipatorySpaceRole case for DeparmentAdmin
+  # - Add new ParticipatorySpaceRole case for DeparmentAdmin.
+  # - Add .to_sym to the `case` test, to avoid error when logged in user is Department Admin
+  # This override affects only line `case role_name&.to_sym`
   #
-  def self.decorate
-    Decidim::ParticipatorySpaceResourceable.class_eval do
-      def user_role_config_for(user, role_name)
-        case role_name&.to_sym
-        when :organization_admin
-          Decidim::ParticipatorySpaceRoleConfig::Admin.new(user)
-        when :admin # ParticipatorySpace admin
-          Decidim::ParticipatorySpaceRoleConfig::ParticipatorySpaceAdmin.new(user)
-        when :department_admin
-          Decidim::ParticipatorySpaceRoleConfig::DepartmentAdmin.new(user)
-        when :valuator
-          Decidim::ParticipatorySpaceRoleConfig::Valuator.new(user)
-        when :moderator
-          Decidim::ParticipatorySpaceRoleConfig::Moderator.new(user)
-        when :collaborator
-          Decidim::ParticipatorySpaceRoleConfig::Collaborator.new(user)
-        else
-          Decidim::ParticipatorySpaceRoleConfig::NullObject.new(user)
-        end
-      end
+  def user_role_config_for(user, role_name)
+    case role_name&.to_sym
+    when :organization_admin
+      Decidim::ParticipatorySpaceRoleConfig::Admin.new(user)
+    when :admin # ParticipatorySpace admin
+      Decidim::ParticipatorySpaceRoleConfig::ParticipatorySpaceAdmin.new(user)
+    when :department_admin
+      Decidim::ParticipatorySpaceRoleConfig::DepartmentAdmin.new(user)
+    when :valuator
+      Decidim::ParticipatorySpaceRoleConfig::Valuator.new(user)
+    when :moderator
+      Decidim::ParticipatorySpaceRoleConfig::Moderator.new(user)
+    when :collaborator
+      Decidim::ParticipatorySpaceRoleConfig::Collaborator.new(user)
+    else
+      Decidim::ParticipatorySpaceRoleConfig::NullObject.new(user)
     end
   end
 end
 
-::Lib::Decidim::ParticipatorySpaceResourceableDecorator.decorate
+require "decidim/assembly"
+Decidim::Assembly.prepend(::Lib::Decidim::ParticipatorySpaceResourceableDecorator)
+require "decidim/participatory_process"
+Decidim::ParticipatoryProcess.prepend(::Lib::Decidim::ParticipatorySpaceResourceableDecorator)
+if Decidim::DepartmentAdmin.conferences_defined?
+  require "decidim/conference"
+  Decidim::Conference.prepend(::Lib::Decidim::ParticipatorySpaceResourceableDecorator)
+end

--- a/lib/decidim/department_admin/engine.rb
+++ b/lib/decidim/department_admin/engine.rb
@@ -47,6 +47,7 @@ module Decidim
         # force the concern to be included so that registry is initialized
         # we choose some random class already including it
         require "decidim/participatory_processes/admin/categories_controller"
+        require "decidim/participatory_processes/admin/components_controller"
         artifact = ::Decidim::ParticipatoryProcesses::Admin::Concerns::ParticipatoryProcessAdmin
         ParticipatoryProcessesAdminConcernPermissions = Class.new(::Decidim::DepartmentAdmin::Permissions)
         register_new_permissions_for(artifact, ParticipatoryProcessesAdminConcernPermissions)

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.7.1"
+      "0.7.2"
     end
   end
 end


### PR DESCRIPTION
Fixes `Lib::Decidim::ParticipatorySpaceResourceableDecorator` by using prepend instead of overriding.

It seems that Decidim models include `Decidim::ParticipatorySpaceResourceable` before the department-admin module overrides it, making `Lib::Decidim::ParticipatorySpaceResourceableDecorator` useless.
By using `prepend` on the models we are sure that the decorator is applied.