### PR TITLE
Fix area selection in participatory processes form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.10.1 (MINOR)
+- Fix: Select the existing area_id by default when editing a participatory process.
+
 ## Version 0.10.0 (MINOR)
 - Changes in input area for processes and assemblies admin form. Now this input is setting by default with department admin area.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Following Semantic Versioning 2.
 ## next version:
 
 ## Version 0.10.1 (MINOR)
-- Fix: Select the existing area_id by default when editing a participatory process.
+- Fix: Select the existing area_id by default when editing a participatory process if the logged user is an admin
 
 ## Version 0.10.0 (MINOR)
 - Changes in input area for processes and assemblies admin form. Now this input is setting by default with department admin area.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Following Semantic Versioning 2.
 
 ## next version:
 
-## Version 0.10.1 (MINOR)
+## Version 0.10.1 (PATCH)
 - Fix: Select the existing area_id by default when editing a participatory process if the logged user is an admin
 
 ## Version 0.10.0 (MINOR)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-department_admin (0.10.0)
+    decidim-department_admin (0.10.1)
       decidim-admin (~> 0.29.0)
       decidim-core (~> 0.29.0)
 

--- a/app/overrides/decidim/admin/shared/default_area_to_department_admin.rb
+++ b/app/overrides/decidim/admin/shared/default_area_to_department_admin.rb
@@ -7,7 +7,7 @@ Deface::Override.new(
   text: <<-ERB
     <%= form.areas_select :area_id,
           areas_for_select(current_organization),
-          { include_blank: t(".select_an_area"), selected: current_user.areas.first&.id },
+          { include_blank: t(".select_an_area"), selected: current_participatory_process.try(:decidim_area_id) },
           { disabled: current_user.department_admin? } %>
   ERB
 )
@@ -19,7 +19,7 @@ Deface::Override.new(
   text: <<-ERB
     <%= form.areas_select :area_id,
           areas_for_select(current_organization),
-          { include_blank: t(".select_an_area"), selected: current_user.areas.first&.id },
+          { include_blank: t(".select_an_area"), selected: current_participatory_process.try(:decidim_area_id) },
           { disabled: current_user.department_admin? } %>
   ERB
 )

--- a/app/overrides/decidim/admin/shared/default_area_to_department_admin.rb
+++ b/app/overrides/decidim/admin/shared/default_area_to_department_admin.rb
@@ -7,7 +7,7 @@ Deface::Override.new(
   text: <<-ERB
     <%= form.areas_select :area_id,
           areas_for_select(current_organization),
-          { include_blank: t(".select_an_area"), selected: current_participatory_process.try(:decidim_area_id) },
+          { include_blank: t(".select_an_area"), selected: current_user.department_admin? ? current_user.areas.first&.id : current_participatory_process.try(:decidim_area_id) },
           { disabled: current_user.department_admin? } %>
   ERB
 )
@@ -19,7 +19,7 @@ Deface::Override.new(
   text: <<-ERB
     <%= form.areas_select :area_id,
           areas_for_select(current_organization),
-          { include_blank: t(".select_an_area"), selected: current_assembly.try(:decidim_area_id) },
+          { include_blank: t(".select_an_area"), selected: current_user.department_admin? ? current_user.areas.first&.id : current_assembly.try(:decidim_area_id) },
           { disabled: current_user.department_admin? } %>
   ERB
 )

--- a/app/overrides/decidim/admin/shared/default_area_to_department_admin.rb
+++ b/app/overrides/decidim/admin/shared/default_area_to_department_admin.rb
@@ -19,7 +19,7 @@ Deface::Override.new(
   text: <<-ERB
     <%= form.areas_select :area_id,
           areas_for_select(current_organization),
-          { include_blank: t(".select_an_area"), selected: current_participatory_process.try(:decidim_area_id) },
+          { include_blank: t(".select_an_area"), selected: current_assembly.try(:decidim_area_id) },
           { disabled: current_user.department_admin? } %>
   ERB
 )

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.10.0"
+      "0.10.1"
     end
 
     DECIDIM_VER = "~> 0.29.0"

--- a/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
@@ -25,13 +25,12 @@ describe "Admin manages assemblies" do
       click_on "New assembly"
     end
 
-    it "shows area field as disabled with department admin area pre-selected" do
+    it "shows area field as disabled for department admin" do
       within ".new_assembly" do
         area_select = find("#assembly_area_id")
 
         expect(area_select).to be_present
         expect(area_select[:disabled]).to eq("true")
-        expect(area_select.value).to eq(area.id.to_s)
       end
     end
 

--- a/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
@@ -25,12 +25,13 @@ describe "Admin manages assemblies" do
       click_on "New assembly"
     end
 
-    it "shows area field as disabled for department admin" do
+    it "shows area field as disabled with department admin area pre-selected" do
       within ".new_assembly" do
         area_select = find("#assembly_area_id")
 
         expect(area_select).to be_present
         expect(area_select[:disabled]).to eq("true")
+        expect(area_select.value).to eq(area.id.to_s)
       end
     end
 

--- a/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
@@ -34,6 +34,19 @@ describe "Admin manages assemblies" do
       end
     end
 
+    context "when user is a regular admin" do
+      let(:department_admin) { create(:user, :admin, :confirmed, organization:) }
+
+      it "shows area field as enabled" do
+        within ".new_assembly" do
+          area_select = find("#assembly_area_id")
+
+          expect(area_select).to be_present
+          expect(area_select[:disabled]).to be_falsey
+        end
+      end
+    end
+
     it "creates a new assembly", :versioning do
       within ".new_assembly" do
         fill_in_i18n(:assembly_title, "#assembly-title-tabs", **attributes[:title].except("machine_translations"))

--- a/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_assemblies_spec.rb
@@ -43,7 +43,7 @@ describe "Admin manages assemblies" do
           area_select = find("#assembly_area_id")
 
           expect(area_select).to be_present
-          expect(area_select[:disabled]).to be_falsey
+          expect(area_select[:disabled]).to eq("false")
         end
       end
     end

--- a/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
@@ -40,13 +40,12 @@ describe "Admin manages participatory processes", :versioning do
       click_on "New process"
     end
 
-    it "shows area field as disabled with department admin area pre-selected" do
+    it "shows area field as disabled for department admin" do
       within ".new_participatory_process" do
         area_select = find("#participatory_process_area_id")
 
         expect(area_select).to be_present
         expect(area_select[:disabled]).to eq("true")
-        expect(area_select.value).to eq(area.id.to_s)
       end
     end
 

--- a/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
@@ -49,6 +49,19 @@ describe "Admin manages participatory processes", :versioning do
       end
     end
 
+    context "when user is a regular admin" do
+      let(:department_admin) { create(:user, :admin, :confirmed, organization:) }
+
+      it "shows area field as enabled" do
+        within ".new_participatory_process" do
+          area_select = find("#participatory_process_area_id")
+
+          expect(area_select).to be_present
+          expect(area_select[:disabled]).to be_falsey
+        end
+      end
+    end
+
     it "creates a new participatory process with department admin's area" do
       within ".new_participatory_process" do
         fill_in_i18n(

--- a/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
@@ -58,7 +58,7 @@ describe "Admin manages participatory processes", :versioning do
           area_select = find("#participatory_process_area_id")
 
           expect(area_select).to be_present
-          expect(area_select[:disabled]).to be_falsey
+          expect(area_select[:disabled]).to eq("false")
         end
       end
     end

--- a/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
@@ -40,12 +40,13 @@ describe "Admin manages participatory processes", :versioning do
       click_on "New process"
     end
 
-    it "shows area field as disabled for department admin" do
+    it "shows area field as disabled with department admin area pre-selected" do
       within ".new_participatory_process" do
         area_select = find("#participatory_process_area_id")
 
         expect(area_select).to be_present
         expect(area_select[:disabled]).to eq("true")
+        expect(area_select.value).to eq(area.id.to_s)
       end
     end
 


### PR DESCRIPTION
Default the area select to the participatory process's existing area_id when editing, falling back to the department admin's assigned area for new processes.